### PR TITLE
Add NamedPipe transport

### DIFF
--- a/CoreRPC/CoreRPC.csproj
+++ b/CoreRPC/CoreRPC.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />

--- a/CoreRPC/Transport/NamedPipe/NamedPipeClientTransport.cs
+++ b/CoreRPC/Transport/NamedPipe/NamedPipeClientTransport.cs
@@ -17,18 +17,20 @@ namespace CoreRPC.Transport.NamedPipe
 
         public async Task<byte[]> SendMessageAsync(byte[] message)
         {
-            var pipe = new NamedPipeClientStream(_serverName, _pipeName, PipeDirection.InOut);
-            await pipe.ConnectAsync();
-            
-            var requestLengthBytes = BitConverter.GetBytes(message.Length);
-            await pipe.WriteAsync(requestLengthBytes, 0, 4);
-            await pipe.WriteAsync(message, 0, message.Length);
-            await pipe.FlushAsync();
+            using (var pipe = new NamedPipeClientStream(_serverName, _pipeName, PipeDirection.InOut))
+            {
+                await pipe.ConnectAsync();
 
-            var responseLengthBytes = await pipe.ReadExactlyAsync(4);
-            var responseLength = BitConverter.ToInt32(responseLengthBytes, 0);
-            var response = await pipe.ReadExactlyAsync(responseLength);
-            return response;
+                var requestLengthBytes = BitConverter.GetBytes(message.Length);
+                await pipe.WriteAsync(requestLengthBytes, 0, 4);
+                await pipe.WriteAsync(message, 0, message.Length);
+                await pipe.FlushAsync();
+
+                var responseLengthBytes = await pipe.ReadExactlyAsync(4);
+                var responseLength = BitConverter.ToInt32(responseLengthBytes, 0);
+                var response = await pipe.ReadExactlyAsync(responseLength);
+                return response;
+            }
         }
     }
 }

--- a/CoreRPC/Transport/NamedPipe/NamedPipeClientTransport.cs
+++ b/CoreRPC/Transport/NamedPipe/NamedPipeClientTransport.cs
@@ -19,17 +19,17 @@ namespace CoreRPC.Transport.NamedPipe
         public async Task<byte[]> SendMessageAsync(byte[] message)
         {
             var pipe = new NamedPipeClientStream(_serverName, _pipeName, PipeDirection.InOut);
-            var messageString = Encoding.UTF8.GetString(message);
-            var writer = new StreamWriter(pipe);
-            var reader = new StreamReader(pipe);
+            var writer = new BinaryWriter(pipe);
+            var reader = new BinaryReader(pipe);
 
             await pipe.ConnectAsync();
-            await writer.WriteLineAsync(messageString);
-            await writer.FlushAsync();
+            writer.Write(message.Length);
+            writer.Write(message);
+            writer.Flush();
 
-            var response = await reader.ReadLineAsync();
-            var responseBytes = Encoding.UTF8.GetBytes(response);
-            return responseBytes;
+            var length = reader.ReadInt32();
+            var response = reader.ReadBytes(length);
+            return response;
         }
     }
 }

--- a/CoreRPC/Transport/NamedPipe/NamedPipeClientTransport.cs
+++ b/CoreRPC/Transport/NamedPipe/NamedPipeClientTransport.cs
@@ -1,0 +1,35 @@
+﻿using System.IO;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CoreRPC.Transport.NamedPipe
+{
+    public sealed class NamedPipeClientTransport : IClientTransport
+    {
+        private readonly string _serverName;
+        private readonly string _pipeName;
+
+        public NamedPipeClientTransport(string pipeName, string serverName = ".")
+        {
+            _serverName = serverName;
+            _pipeName = pipeName;
+        }
+
+        public async Task<byte[]> SendMessageAsync(byte[] message)
+        {
+            var pipe = new NamedPipeClientStream(_serverName, _pipeName, PipeDirection.InOut);
+            var messageString = Encoding.UTF8.GetString(message);
+            var writer = new StreamWriter(pipe);
+            var reader = new StreamReader(pipe);
+
+            await pipe.ConnectAsync();
+            await writer.WriteLineAsync(messageString);
+            await writer.FlushAsync();
+
+            var response = await reader.ReadLineAsync();
+            var responseBytes = Encoding.UTF8.GetBytes(response);
+            return responseBytes;
+        }
+    }
+}

--- a/CoreRPC/Transport/NamedPipe/NamedPipeClientTransport.cs
+++ b/CoreRPC/Transport/NamedPipe/NamedPipeClientTransport.cs
@@ -17,7 +17,7 @@ namespace CoreRPC.Transport.NamedPipe
 
         public async Task<byte[]> SendMessageAsync(byte[] message)
         {
-            using (var pipe = new NamedPipeClientStream(_serverName, _pipeName, PipeDirection.InOut))
+            using (var pipe = new NamedPipeClientStream(_serverName, _pipeName, PipeDirection.InOut, PipeOptions.Asynchronous))
             {
                 await pipe.ConnectAsync();
 

--- a/CoreRPC/Transport/NamedPipe/NamedPipeHost.cs
+++ b/CoreRPC/Transport/NamedPipe/NamedPipeHost.cs
@@ -15,7 +15,10 @@ namespace CoreRPC.Transport.NamedPipe
         {
             while (!token.IsCancellationRequested)
             {
-                var pipe = new NamedPipeServerStream(pipeName, PipeDirection.InOut);
+                var pipe = new NamedPipeServerStream(
+                    pipeName, PipeDirection.InOut, 1,
+                    PipeTransmissionMode.Byte,
+                    PipeOptions.Asynchronous);
                 try
                 {
                     await pipe.WaitForConnectionAsync(token);

--- a/CoreRPC/Transport/NamedPipe/NamedPipeHost.cs
+++ b/CoreRPC/Transport/NamedPipe/NamedPipeHost.cs
@@ -11,7 +11,7 @@ namespace CoreRPC.Transport.NamedPipe
 
         public NamedPipeHost(IRequestHandler engine) => _engine = engine;
 
-        public void StartListening(string pipeName, CancellationToken token) => Task.Run(async () =>
+        public void StartListening(string pipeName, CancellationToken token = default(CancellationToken)) => Task.Run(async () =>
         {
             while (!token.IsCancellationRequested)
             {

--- a/CoreRPC/Transport/NamedPipe/NamedPipeHost.cs
+++ b/CoreRPC/Transport/NamedPipe/NamedPipeHost.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CoreRPC.Transport.NamedPipe
+{
+    public sealed class NamedPipeHost : IDisposable
+    {
+        private readonly IRequestHandler _engine;
+        private NamedPipeServerStream _pipe;
+        private bool _isDisposed;
+
+        public NamedPipeHost(IRequestHandler engine) => _engine = engine;
+
+        public void StartListening(string pipeName) => Task.Run(async () =>
+        {
+            while (!_isDisposed)
+            {
+                using (_pipe = new NamedPipeServerStream(pipeName, PipeDirection.InOut))
+                using (var reader = new StreamReader(_pipe))
+                using (var writer = new StreamWriter(_pipe))
+                {
+                    await _pipe.WaitForConnectionAsync();
+                    var message = await reader.ReadLineAsync();
+                    var messageBytes = Encoding.UTF8.GetBytes(message);
+
+                    var responseBytes = new byte[0];
+                    await _engine.HandleRequest(new Request(messageBytes, bytes => responseBytes = bytes));
+
+                    var responseString = Encoding.UTF8.GetString(responseBytes);
+                    await writer.WriteLineAsync(responseString);
+                    await writer.FlushAsync();
+                }
+            }
+        });
+
+        public void Dispose()
+        {
+            if (_isDisposed) return;
+            _isDisposed = true;
+            _pipe?.Dispose();
+        }
+
+        private sealed class Request : IRequest
+        {
+            private readonly Action<byte[]> _respond;
+
+            public Request(byte[] data, Action<byte[]> respond)
+            {
+                Data = data;
+                _respond = respond;
+            }
+
+            public byte[] Data { get; }
+
+            public object Context { get; } = null;
+
+            public Task RespondAsync(byte[] data)
+            {
+                _respond(data);
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/CoreRPC/Transport/NamedPipe/NamedPipeHost.cs
+++ b/CoreRPC/Transport/NamedPipe/NamedPipeHost.cs
@@ -22,12 +22,13 @@ namespace CoreRPC.Transport.NamedPipe
                 try
                 {
                     await pipe.WaitForConnectionAsync(token);
-                    ProcessRequest(pipe, token);
                 }
-                catch (OperationCanceledException)
+                catch
                 {
                     pipe.Dispose();
+                    continue;
                 }
+                ProcessRequest(pipe, token);
             }
         });
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,10 @@ Start your server using either TCP or HTTP protocol.
 
 ```cs
 // TCP
-public void StartServer()
-{
-    var router = new DefaultTargetSelector();
-    router.Register<IService, Service>();
-    var host = new TcpHost(new Engine().CreateRequestHandler(router));
-    host.StartListening(new IPEndPoint(IPAddress.Loopback, 9000));
-}
+var router = new DefaultTargetSelector();
+router.Register<IService, Service>();
+var host = new TcpHost(new Engine().CreateRequestHandler(router));
+host.StartListening(new IPEndPoint(IPAddress.Loopback, 9000));
     
 // ASP.NET Core (HTTP)
 public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -48,6 +45,12 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
     router.Register<IService, Service>();
     app.UseCoreRPC("/rpc", new Engine().CreateRequestHandler(router));
 }
+
+// Named Pipes
+var router = new DefaultTargetSelector();
+router.Register<IService, Service>();
+var host = new NamedPipeHost(new Engine().CreateRequestHandler(router));
+host.StartListening("AwesomePipeName");
 ```
 
 ### Client
@@ -57,12 +60,16 @@ Use the protocol your server uses and call remote procedures!
 ```cs
 // TCP
 var transport = new TcpClientTransport(IPAddress.Parse("127.0.0.1");
-var proxy = new Engine().CreateProxy<IService>(transport, 9000));
+var proxy = new Engine().CreateProxy<IService>(transport, 9000);
 
 // HTTP 
 var transport = new HttpClientTransport("http://example.com/rpc");
 var proxy = new Engine().CreateProxy<IService>(transport);
 var res = await proxy.Foo(1);
+
+// Named Pipes
+var transport = new NamedPipeClientTransport("AwesomePipeName");
+var proxy = new Engine().CreateProxy<IService>(transport);
 ```
 
 ### Assembly Scanning

--- a/Tests/NamedPipeTransportTests.cs
+++ b/Tests/NamedPipeTransportTests.cs
@@ -12,15 +12,14 @@ namespace Tests
         public async Task CheckConnectivity()
         {
             const string pipe = "NamedPipeTransportTests";
-            using (var server = new NamedPipeHost(new Handler()))
-            {
-                server.StartListening(pipe);
-                var message = new byte[] { 1, 2, 3, 4, 5 };
-                var client = new NamedPipeClientTransport(pipe);
+            var server = new NamedPipeHost(new Handler());
+            
+            server.StartListening(pipe);
+            var message = new byte[] { 1, 2, 3, 4, 5 };
+            var client = new NamedPipeClientTransport(pipe);
 
-                var data = await client.SendMessageAsync(message);
-                Assert.True(data.SequenceEqual(message));
-            }
+            var data = await client.SendMessageAsync(message);
+            Assert.True(data.SequenceEqual(message));
         }
 
         public class Handler : IRequestHandler

--- a/Tests/NamedPipeTransportTests.cs
+++ b/Tests/NamedPipeTransportTests.cs
@@ -1,0 +1,32 @@
+﻿using CoreRPC.Transport.NamedPipe;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using CoreRPC.Transport;
+using Xunit;
+
+namespace Tests
+{
+    public class NamedPipeTransportTests
+    {
+        [Fact]
+        public async Task CheckConnectivity()
+        {
+            const string pipe = "NamedPipeTransportTests";
+            using (var server = new NamedPipeHost(new Handler()))
+            {
+                server.StartListening(pipe);
+                var message = new byte[] { 1, 2, 3, 4, 5 };
+                var client = new NamedPipeClientTransport(pipe);
+
+                var data = await client.SendMessageAsync(message);
+                Assert.True(data.SequenceEqual(message));
+            }
+        }
+
+        public class Handler : IRequestHandler
+        {
+            public Task HandleRequest(IRequest req) => req.RespondAsync(req.Data);
+        }
+    }
+}

--- a/Tests/NamedPipeTransportTests.cs
+++ b/Tests/NamedPipeTransportTests.cs
@@ -1,6 +1,5 @@
 ﻿using CoreRPC.Transport.NamedPipe;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using CoreRPC.Transport;
 using Xunit;


### PR DESCRIPTION
This allows using named pipes for a lightweight inter-process communication.

Server:

```cs
var router = new DefaultTargetSelector();
router.Register<IService, Service>();
var host = new NamedPipeHost(new Engine().CreateRequestHandler(router));
host.StartListening("AwesomePipeName");
```

Client:

```cs
var transport = new NamedPipeClientTransport("AwesomePipeName");
var proxy = new Engine().CreateProxy<IService>(transport);
````