### PR TITLE
fix: Don't generate Typescript properties for statics

### DIFF
--- a/CoreRPC/Typescript/TypescriptTypeMapping.cs
+++ b/CoreRPC/Typescript/TypescriptTypeMapping.cs
@@ -46,6 +46,9 @@ namespace CoreRPC.Typescript
                 code.BeginInterface(tsName);
                 foreach (var p in type.GetProperties())
                 {
+                    if (p.GetAccessors(false).Any(x => x.IsStatic))
+                        continue;
+
                     var typeName = MapType(p.PropertyType);
                     code.AppendInterfaceProperty(_opts.DtoFieldNamingPolicy(p.Name), typeName);
                 }

--- a/Tests/TypescriptAspNetCoreTests.cs
+++ b/Tests/TypescriptAspNetCoreTests.cs
@@ -88,7 +88,7 @@ namespace Tests
     public class MyStaticFieldsDto
     {
         public string RegularProperty { get; set; } = "Foo";
-        public static string StaticProperty { get; set; } = "I'm a static property and should be stripped away.";
+        public static string StaticPropertyThisTextShouldNotExistInGeneratedFile { get; set; } = "I'm a static.";
     }
 
     [RegisterRpc]
@@ -169,6 +169,10 @@ namespace Tests
             var output = outputTask.Result;
             if (output.Trim() != "OK")
                 throw new Exception(errorTask.Result);
+
+            var apiTs = Path.Combine(jsDir, "api.ts");
+            var generatedStuff = File.ReadAllText(apiTs);
+            Assert.DoesNotContain("ThisTextShouldNotExistInGeneratedFile", generatedStuff);
         }
     }
 #endif

--- a/Tests/TypescriptAspNetCoreTests.cs
+++ b/Tests/TypescriptAspNetCoreTests.cs
@@ -84,6 +84,18 @@ namespace Tests
     {
         public Dictionary<string, int> Do(MyGenericDto<int, string> dto) => new Dictionary<string, int> {[dto.Prop2] = dto.Prop1};
     }
+
+    public class MyStaticFieldsDto
+    {
+        public string RegularProperty { get; set; } = "Foo";
+        public static string StaticProperty { get; set; } = "I'm a static property and should be stripped away.";
+    }
+
+    [RegisterRpc]
+    public class StaticFields
+    {
+        public MyStaticFieldsDto Do() => new MyStaticFieldsDto();
+    }
     
     class RpcStartup
     {


### PR DESCRIPTION
With this PR, we are no longer generating public static fields as Typescript DTOs.