### PR TITLE
feature: Add TsIgnoreAttribute

### DIFF
--- a/CoreRPC/TsIgnoreAttribute.cs
+++ b/CoreRPC/TsIgnoreAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace CoreRPC
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class TsIgnoreAttribute : Attribute
+    {
+    }
+}

--- a/CoreRPC/Typescript/TsIgnoreAttribute.cs
+++ b/CoreRPC/Typescript/TsIgnoreAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace CoreRPC
+namespace CoreRPC.Typescript
 {
     [AttributeUsage(AttributeTargets.Property)]
     public class TsIgnoreAttribute : Attribute

--- a/CoreRPC/Typescript/TypescriptTypeMapping.cs
+++ b/CoreRPC/Typescript/TypescriptTypeMapping.cs
@@ -49,6 +49,9 @@ namespace CoreRPC.Typescript
                     if (p.GetAccessors(false).Any(x => x.IsStatic))
                         continue;
 
+                    if (Attribute.IsDefined(p, typeof(TsIgnoreAttribute)))
+                        continue;
+
                     var typeName = MapType(p.PropertyType);
                     code.AppendInterfaceProperty(_opts.DtoFieldNamingPolicy(p.Name), typeName);
                 }

--- a/Tests/TypescriptAspNetCoreTests.cs
+++ b/Tests/TypescriptAspNetCoreTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using CoreRPC;
 using CoreRPC.AspNetCore;
 using CoreRPC.Transferable;
+using CoreRPC.Typescript;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;

--- a/Tests/TypescriptAspNetCoreTests.cs
+++ b/Tests/TypescriptAspNetCoreTests.cs
@@ -87,7 +87,7 @@ namespace Tests
 
     public class MyStaticFieldsDto
     {
-        public string RegularProperty { get; set; } = "Foo";
+        public string MyStaticFieldsDtoRegularProperty { get; set; } = "Foo";
         public static string StaticPropertyThisTextShouldNotExistInGeneratedFile { get; set; } = "I'm a static.";
     }
 
@@ -96,7 +96,24 @@ namespace Tests
     {
         public MyStaticFieldsDto Do() => new MyStaticFieldsDto();
     }
-    
+
+    public class MyTsIgnoreDto
+    {
+        public string MyTsIgnoreDtoRegularProperty { get; set; } = "Foo";
+
+        [TsIgnore]
+        public string ThisTextShouldNotExistInGeneratedFile { get; set; } = "I'm ignored.";
+
+        [TsIgnore]
+        public string ComputedThisTextShouldNotExistInGeneratedFile => "I'm computed.";
+    }
+
+    [RegisterRpc]
+    public class TsIgnoreProperties
+    {
+        public MyTsIgnoreDto Do() => new MyTsIgnoreDto();
+    }
+
     class RpcStartup
     {
         public static string JsDir;
@@ -172,6 +189,8 @@ namespace Tests
 
             var apiTs = Path.Combine(jsDir, "api.ts");
             var generatedStuff = File.ReadAllText(apiTs);
+            Assert.Contains(nameof(MyStaticFieldsDto.MyStaticFieldsDtoRegularProperty), generatedStuff);
+            Assert.Contains(nameof(MyTsIgnoreDto.MyTsIgnoreDtoRegularProperty), generatedStuff);
             Assert.DoesNotContain("ThisTextShouldNotExistInGeneratedFile", generatedStuff);
         }
     }


### PR DESCRIPTION
This allows annotating properties that we'd like to exclude from TS generated code if a property doesn't make sense there.
```cs
public class MyTsIgnoreDto
{
    public string Included { get; set; } = "Foo";

    [TsIgnore]
    public string Excluded => "I'm computed.";
}
```
 