### PR TITLE
feature: Use GitHub Actions for Pushing NuGet Packages

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,103 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches: [ master ]
+
+env:
+  configuration: Release
+  productNamespacePrefix: "CoreRPC"
+
+jobs:
+  build:
+    runs-on: windows-latest
+    outputs:
+      nbgv: ${{ steps.nbgv.outputs.SemVer2 }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+
+    - name: NBGV
+      id: nbgv
+      uses: dotnet/nbgv@master
+      with:
+        setAllVars: true
+
+    - name: NuGet Restore
+      run: dotnet restore
+      working-directory: src
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1
+
+    - name: Build
+      run: msbuild /t:build,pack /maxcpucount /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=${{ env.configuration }}
+      working-directory: src
+
+    - name: Create NuGet Artifacts
+      uses: actions/upload-artifact@master
+      with:
+        name: nuget
+        path: '**/*.nupkg'
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: contains(github.event.pull_request.labels.*.name, 'release') && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Download NuGet Packages
+      uses: actions/download-artifact@v2
+      with:
+        name: nuget
+
+    - name: Save SignClient Configuration
+      run: 'echo "$SIGN_CLIENT_CONFIG" > SignPackages.json'
+      shell: bash
+      env:
+        SIGN_CLIENT_CONFIG: ${{secrets.SIGN_CLIENT_CONFIG}}
+
+    - name: Sign NuGet Packages
+      uses: glennawatson/signclient@v1
+      with:
+        input-files: '**/*.nupkg'
+        sign-client-secret: ${{ secrets.SIGN_CLIENT_SECRET }}
+        sign-client-user: ${{ secrets.SIGN_CLIENT_USER_ID }}
+        project-name: reactiveui
+        description: reactiveui
+        config-file: SignPackages.json
+
+    - name: Changelog
+      uses: glennawatson/ChangeLog@v1
+      id: changelog
+
+    - name: Create Release
+      uses: actions/create-release@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      with:
+          tag_name: ${{ needs.build.outputs.nbgv }}
+          release_name: ${{ needs.build.outputs.nbgv }}
+          body: |
+            ${{ steps.changelog.outputs.commitLog }}
+
+    - name: NuGet Push
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
+        SOURCE_URL: https://api.nuget.org/v3/index.json
+      run: |
+        dotnet nuget push -s ${{ env.SOURCE_URL }} -k ${{ env.NUGET_AUTH_TOKEN }} **/*.nupkg

--- a/CoreRPC.AspNetCore/CoreRPC.AspNetCore.csproj
+++ b/CoreRPC.AspNetCore/CoreRPC.AspNetCore.csproj
@@ -1,10 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
     <ProjectReference Include="..\CoreRPC\CoreRPC.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/CoreRPC/CoreRPC.csproj
+++ b/CoreRPC/CoreRPC.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IsPackable>true</IsPackable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
@@ -18,5 +20,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netcoreapp3.0;net461</TargetFrameworks>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
     <DefineConstants>$(DefineConstants);LEGACY_NET</DefineConstants>

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.5",
+    "version": "0.6",
     "publicReleaseRefSpec": [
       "^refs/heads/main$", // we release out of main
       "^refs/heads/rel/\\d+\\.\\d+\\.\\d+" // we also release branches starting with rel/N.N.N

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.6",
+    "version": "0.5.6",
     "publicReleaseRefSpec": [
       "^refs/heads/main$", // we release out of main
       "^refs/heads/rel/\\d+\\.\\d+\\.\\d+" // we also release branches starting with rel/N.N.N

--- a/version.json
+++ b/version.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.5",
+    "publicReleaseRefSpec": [
+      "^refs/heads/main$", // we release out of main
+      "^refs/heads/rel/\\d+\\.\\d+\\.\\d+" // we also release branches starting with rel/N.N.N
+    ],
+    "nugetPackageVersion":{
+      "semVer": 2
+    },
+    "cloudBuild": {
+      "setVersionVariables": true,
+      "buildNumber": {
+        "enabled": false
+      }
+    }
+  }


### PR DESCRIPTION
This PR incorporates GitHub Actions setup for building and pushing NuGet packages. We are using [NGBV](https://github.com/dotnet/Nerdbank.GitVersioning) for version increments.

**UPD** Closing based on the conversation in Telegram. The preferred approach for this repository is to push a new NuGet package when a new `git tag` is pushed, and also to avoid using auto version increments via `ngbv`. Probably worth investigating further.