### PR TITLE
feature: Add CoreRPC.Testing

### DIFF
--- a/CoreRPC.Testing/CoreRPC.Testing.csproj
+++ b/CoreRPC.Testing/CoreRPC.Testing.csproj
@@ -1,16 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
-
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <ProjectReference Include="..\CoreRPC.AspNetCore\CoreRPC.AspNetCore.csproj" />
     </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\CoreRPC.AspNetCore\CoreRPC.AspNetCore.csproj" />
-      <ProjectReference Include="..\CoreRPC\CoreRPC.csproj" />
-    </ItemGroup>
-
 </Project>

--- a/CoreRPC.Testing/CoreRPC.Testing.csproj
+++ b/CoreRPC.Testing/CoreRPC.Testing.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\CoreRPC.AspNetCore\CoreRPC.AspNetCore.csproj" />
+      <ProjectReference Include="..\CoreRPC\CoreRPC.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/CoreRPC.Testing/IRpcExec.cs
+++ b/CoreRPC.Testing/IRpcExec.cs
@@ -23,7 +23,7 @@ namespace CoreRPC.Testing
 
         protected RpcListBase(
             string uri,
-            Dictionary<string, string> headers,
+            Dictionary<string, string> headers = null,
             HttpClient http = null,
             JsonSerializerSettings settings = null)
         {

--- a/CoreRPC.Testing/IRpcExec.cs
+++ b/CoreRPC.Testing/IRpcExec.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace CoreRPC.Testing
+{
+    public interface IRpcExec<TRpc>
+    {
+        TResponse Call<TResponse>(Expression<Func<TRpc, TResponse>> expression);
+        Task<TResponse> Call<TResponse>(Expression<Func<TRpc, Task<TResponse>>> expression);
+    }
+
+    public abstract class RpcListBase
+    {
+        private static readonly Lazy<HttpClient> SharedClient = new Lazy<HttpClient>(() => new HttpClient());
+        private readonly Dictionary<string, string> _headers;
+        private readonly JsonSerializerSettings _settings;
+        private readonly HttpClient _http;
+        private readonly string _baseUri;
+
+        protected RpcListBase(
+            string uri,
+            Dictionary<string, string> headers,
+            HttpClient http = null,
+            JsonSerializerSettings settings = null)
+        {
+            _baseUri = uri;
+            _headers = headers;
+            _settings = settings;
+            _http = http ?? SharedClient.Value;
+        }
+
+        protected IRpcExec<TRpc> Get<TRpc>() => new RpcExecHelper<TRpc>(_http, _baseUri, _headers, settings: _settings);
+    }
+}

--- a/CoreRPC.Testing/RpcExecHelper.cs
+++ b/CoreRPC.Testing/RpcExecHelper.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Net.Http;
+using System.Threading.Tasks;
+using CoreRPC.AspNetCore;
+using CoreRPC.Binding;
+using CoreRPC.Binding.Default;
+using CoreRPC.Routing;
+using Newtonsoft.Json;
+
+namespace CoreRPC.Testing
+{
+    public class RpcExecHelper<TRpc> : IRpcExec<TRpc>, IDisposable
+    {
+        private readonly Dictionary<string, string> _headers;
+        private readonly JsonSerializerSettings _settings;
+        private readonly ITargetNameExtractor _extractor;
+        private readonly IMethodBinder _binder;
+        private readonly HttpClient _http;
+        private readonly string _uri;
+
+        public RpcExecHelper(
+            HttpClient http,
+            string uri,
+            Dictionary<string, string> headers,
+            ITargetNameExtractor extractor = null,
+            IMethodBinder binder = null,
+            JsonSerializerSettings settings = null)
+        {
+            _http = http;
+            _uri = uri;
+            _headers = headers;
+            _settings = settings;
+            _extractor = extractor ?? new AspNetCoreTargetNameExtractor();
+            _binder = binder ?? new DefaultMethodBinder();
+        }
+
+        public TRes Call<TRes>(Expression<Func<TRpc, TRes>> cb)
+        {
+            var response = CallImpl(cb);
+            var deserialized = JsonConvert.DeserializeObject<ResultResponse<TRes>>(response, _settings);
+            if (deserialized is null)
+                throw new InvalidOperationException($"Received null value when trying to deserialize {response}");
+            var instance = deserialized.Result;
+            return instance;
+        }
+
+        public Task<TRes> Call<TRes>(Expression<Func<TRpc, Task<TRes>>> cb)
+        {
+            var response = CallImpl(cb);
+            var deserialized = JsonConvert.DeserializeObject<ResultResponse<TRes>>(response, _settings);
+            if (deserialized is null)
+                throw new InvalidOperationException($"Received null value when trying to deserialize {response}");
+            var instance = deserialized.Result;
+            return Task.FromResult(instance);
+        }
+
+        private string CallImpl<TRes>(Expression<Func<TRpc, TRes>> cb)
+        {
+            if (cb.Parameters.Count != 1)
+                throw new InvalidOperationException();
+            var mcall = (MethodCallExpression) cb.Body;
+            var sig = _binder.GetMethodSignature(mcall.Method);
+            var args = mcall.Arguments
+                .Select(argument =>
+                    Expression.Lambda<Func<object>>(
+                            Expression.Convert(argument, typeof(object)))
+                        .Compile()
+                        .Invoke())
+                .ToList();
+
+            var name = _extractor.GetTargetName(cb.Parameters[0].Type);
+            var content = new StringContent(JsonConvert.SerializeObject(new
+            {
+                Target = name,
+                MethodSignature = sig,
+                Arguments = args
+            }));
+
+            if (_headers != null)
+                foreach (var hdr in _headers)
+                    content.Headers.Add(hdr.Key, hdr.Value);
+
+            using (var response = _http.PostAsync(_uri, content).Result)
+            {
+                var json = response.Content.ReadAsStringAsync().Result;
+                if (!response.IsSuccessStatusCode)
+                    throw new Exception("Non-zero status code " + response.StatusCode + ":\n\n" + json);
+                var error = JsonConvert.DeserializeObject<ExceptionResponse>(json);
+                if (error?.Exception != null)
+                    throw new Exception(error.Exception);
+                return json;
+            }
+        }
+
+        public void Dispose() => _http.Dispose();
+
+        private class ResultResponse<T>
+        {
+            public T Result { get; set; }
+        }
+
+        private class ExceptionResponse
+        {
+            public string Exception { get; set; }
+        }
+    }
+}

--- a/CoreRPC.sln
+++ b/CoreRPC.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreRPC.AspNetCore", "CoreRPC.AspNetCore\CoreRPC.AspNetCore.csproj", "{20E4095E-D61A-46D3-8BDE-FD7E786D36F4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreRPC.Testing", "CoreRPC.Testing\CoreRPC.Testing.csproj", "{AE2104C8-05E5-4D23-8711-21CFB7EDF9AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{20E4095E-D61A-46D3-8BDE-FD7E786D36F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{20E4095E-D61A-46D3-8BDE-FD7E786D36F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{20E4095E-D61A-46D3-8BDE-FD7E786D36F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE2104C8-05E5-4D23-8711-21CFB7EDF9AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE2104C8-05E5-4D23-8711-21CFB7EDF9AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE2104C8-05E5-4D23-8711-21CFB7EDF9AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE2104C8-05E5-4D23-8711-21CFB7EDF9AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/TestingTests.cs
+++ b/Tests/TestingTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CoreRPC.AspNetCore;
+using CoreRPC.Testing;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Tests
+{
+    public class TestingTests
+    {
+        public class InjectableService
+        {
+            public int Sum(int a, int b) => a + b;
+
+            public int Multiply(int a, int b) => a * b;
+        }
+
+        [RegisterRpc]
+        public class AnonComputeRpc
+        {
+            private readonly InjectableService _service;
+
+            public AnonComputeRpc(InjectableService service) => _service = service;
+
+            public int Sum(int a, int b) => _service.Sum(a, b);
+
+            public int Multiply(int a, int b) => _service.Multiply(a, b);
+        }
+
+        [RegisterRpc]
+        public class AnonGreeterRpc
+        {
+            public string Greet(string name) => $"Hello, {name}!";
+        }
+
+        [RegisterRpc]
+        public class SecureComputeRpc : IHttpContextAwareRpc
+        {
+            private const string SecureToken = "foobar";
+            private readonly InjectableService _service;
+
+            public SecureComputeRpc(InjectableService service) => _service = service;
+
+            public int Sum(int a, int b) => _service.Sum(a, b);
+
+            public int Multiply(int a, int b) => _service.Multiply(a, b);
+
+            public Task<object> OnExecuteRpcCall(HttpContext context, Func<Task<object>> action)
+            {
+                var header = context.Request.Headers["X-Auth"].FirstOrDefault();
+                if (header != null && header == SecureToken)
+                    return action();
+                context.Response.StatusCode = 401;
+                return Task.FromResult((object) new { Error = "Not authorized!" });
+            }
+        }
+
+        public class Startup
+        {
+            public void ConfigureServices(IServiceCollection services) => services.AddSingleton<InjectableService>();
+
+            public void Configure(IApplicationBuilder app) =>
+                app.UseCoreRpc("/rpc", options => options.RpcTypeResolver = () => new[]
+                {
+                    typeof(SecureComputeRpc),
+                    typeof(AnonComputeRpc),
+                    typeof(AnonGreeterRpc),
+                });
+        }
+
+        // This is a sample helper class used for writing unit tests.
+        public sealed class AnonRpcList : RpcListBase
+        {
+            public AnonRpcList(string uri) : base(uri) { }
+
+            public IRpcExec<AnonComputeRpc> Compute => Get<AnonComputeRpc>();
+            public IRpcExec<AnonGreeterRpc> Greeter => Get<AnonGreeterRpc>();
+        }
+
+        // This is a sample helper class used for writing unit tests for authorized RPCs.
+        public sealed class SecureRpcList : RpcListBase
+        {
+            public SecureRpcList(string uri) : base(uri, new Dictionary<string, string> {["X-Auth"] = "foobar"}) { }
+
+            public IRpcExec<SecureComputeRpc> Compute => Get<SecureComputeRpc>();
+        }
+
+        [Theory]
+        [InlineData(1, 1, 2, 1)]
+        [InlineData(2, 2, 4, 4)]
+        [InlineData(3, 2, 5, 6)]
+        public async Task ShouldCallRemoteProceduresWithoutInterfaceDefinition(int a, int b, int sum, int product)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseFreePort()
+                .UseStartup<Startup>()
+                .Build();
+
+            await host.StartAsync();
+            var addresses = host.ServerFeatures.Get<IServerAddressesFeature>();
+            var address = addresses.Addresses.First().TrimEnd('/') + "/rpc";
+
+            var anon = new AnonRpcList(address);
+            Assert.Equal("Hello, John!", anon.Greeter.Call(api => api.Greet("John")));
+            Assert.Equal(sum, anon.Compute.Call(api => api.Sum(a, b)));
+            Assert.Equal(product, anon.Compute.Call(api => api.Multiply(a, b)));
+
+            var secure = new SecureRpcList(address);
+            Assert.Equal(sum, secure.Compute.Call(api => api.Sum(a, b)));
+            Assert.Equal(product, secure.Compute.Call(api => api.Multiply(a, b)));
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CoreRPC.AspNetCore\CoreRPC.AspNetCore.csproj" />
+    <ProjectReference Include="..\CoreRPC.Testing\CoreRPC.Testing.csproj" />
     <ProjectReference Include="..\CoreRPC\CoreRPC.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
So in the unit tests we can write:
```cs
public sealed class SecureRpcList : RpcListBase
{
    public SecureRpcList(string uri) : base(uri, new Dictionary<string, string> {["X-Auth"] = "foobar"}) { }

    public IRpcExec<SecureComputeRpc> Compute => Get<SecureComputeRpc>();
}
```
And then call the RPCs without explicit interfaces (e.g. exposed to TypeScript) like this (with [FluentAssertions](https://github.com/fluentassertions/fluentassertions)):
```cs
var secure = new SecureRpcList(address);
secure.Compute.Call(api => api.Sum(2, 2)).Should().Be(4);
secure.Compute.Call(api => api.Multiply(2, 2)).Should().Be(4);
```