### PR TITLE
feature: Error Handling Extensibility Point

### DIFF
--- a/CoreRPC.AspNetCore/AspNetCoreHost.cs
+++ b/CoreRPC.AspNetCore/AspNetCoreHost.cs
@@ -66,7 +66,8 @@ namespace CoreRPC.AspNetCore
             var selector = new DefaultTargetSelector(new AspNetCoreTargetFactory(), extractor);
             foreach (var t in types)
                 selector.Register(extractor.GetTargetName(t), t);
-            return builder.UseCoreRpc(path, engine.CreateRequestHandler(selector, new CallInterceptor(cfg.Interceptors)));
+            return builder.UseCoreRpc(path, engine.CreateRequestHandler(selector,
+                new CallInterceptor(cfg.Interceptors), cfg.ErrorHandler));
         }
 
         class CallInterceptor : IMethodCallInterceptor
@@ -112,5 +113,6 @@ namespace CoreRPC.AspNetCore
         };
         public List<IMethodCallInterceptor> Interceptors { get; } = new List<IMethodCallInterceptor>();
         public Func<IEnumerable<Type>> RpcTypeResolver { get; set; }
+        public IRequestErrorHandler ErrorHandler { get; set; }
     }
 }

--- a/CoreRPC/Engine.cs
+++ b/CoreRPC/Engine.cs
@@ -25,14 +25,17 @@ namespace CoreRPC
         }
 
 
-        public IRequestHandler CreateRequestHandler(ITargetSelector selector)
+        public IRequestHandler CreateRequestHandler(ITargetSelector selector, IRequestErrorHandler errors = null)
         {
-            return new RequestHandler(selector, _binder, _serializer, null);
+            return new RequestHandler(selector, _binder, _serializer, null, errors);
         }
         
-        public IRequestHandler CreateRequestHandler(ITargetSelector selector, IMethodCallInterceptor interceptor)
+        public IRequestHandler CreateRequestHandler(
+            ITargetSelector selector,
+            IMethodCallInterceptor interceptor,
+            IRequestErrorHandler errors = null)
         {
-            return new RequestHandler(selector, _binder, _serializer, interceptor);
+            return new RequestHandler(selector, _binder, _serializer, interceptor, errors);
         }
 
         public TInterface CreateProxy<TInterface>(IClientTransport transport, ITargetNameExtractor nameExtractor = null)

--- a/CoreRPC/IRequestErrorHandler.cs
+++ b/CoreRPC/IRequestErrorHandler.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace CoreRPC
+{
+    public interface IRequestErrorHandler
+    {
+        void HandleError(Exception exception);
+    }
+}

--- a/CoreRPC/IRequestErrorHandler.cs
+++ b/CoreRPC/IRequestErrorHandler.cs
@@ -4,6 +4,6 @@ namespace CoreRPC
 {
     public interface IRequestErrorHandler
     {
-        void HandleError(Exception exception);
+        string HandleError(Exception exception);
     }
 }

--- a/CoreRPC/RequestHandler.cs
+++ b/CoreRPC/RequestHandler.cs
@@ -124,8 +124,8 @@ namespace CoreRPC
                 {
                     try
                     {
-                        _errors.HandleError(ex);
-                        SerializeError(response, "500");
+                        var handled = _errors.HandleError(ex);
+                        SerializeError(response, handled ?? "Internal Server Error");
                     }
                     catch
                     {

--- a/CoreRPC/RequestHandler.cs
+++ b/CoreRPC/RequestHandler.cs
@@ -6,7 +6,6 @@ using CoreRPC.Routing;
 using CoreRPC.Serialization;
 using CoreRPC.Transferable;
 using CoreRPC.Transport;
-using System.Reflection;
 using CoreRPC.Utility;
 using Microsoft.IO;
 
@@ -18,14 +17,20 @@ namespace CoreRPC
         private readonly IMethodBinder _binder;
         private readonly IMethodCallSerializer _serializer;
         private readonly IMethodCallInterceptor _interceptor;
+        private readonly IRequestErrorHandler _errors;
 
-        public RequestHandler(ITargetSelector selector, IMethodBinder binder,
-            IMethodCallSerializer serializer, IMethodCallInterceptor interceptor)
+        public RequestHandler(
+            ITargetSelector selector,
+            IMethodBinder binder,
+            IMethodCallSerializer serializer,
+            IMethodCallInterceptor interceptor,
+            IRequestErrorHandler errors)
         {
             _selector = selector;
             _binder = binder;
             _serializer = serializer;
             _interceptor = interceptor;
+            _errors = errors;
         }
 
         static async Task<object> ConvertToTask(object ires)
@@ -115,21 +120,50 @@ namespace CoreRPC
 
             if (ex != null)
             {
-                response.Position = 0;
-                response.SetLength(0);
-                _serializer.SerializeException(response, ex.ToString());
-                response.Position = 0;
+                if (_errors != null)
+                {
+                    try
+                    {
+                        _errors.HandleError(ex);
+                        SerializeError(response, "500");
+                    }
+                    catch
+                    {
+                        SerializeError(response, ex.ToString());
+                    }
+                }
+                else
+                {
+                    SerializeError(response, ex.ToString());
+                }
             }
 
             try
             {
                 await req.RespondAsync(response);
             }
-            catch
+            catch (Exception fatal)
             {
-                //TODO: redirect it somewhere?
+                if (_errors != null)
+                {
+                    try
+                    {
+                        _errors.HandleError(fatal);
+                    }
+                    catch
+                    {
+                        // We've tried.
+                    }
+                }
             }
         }
 
+        void SerializeError(RecyclableMemoryStream response, string error)
+        {
+            response.Position = 0;
+            response.SetLength(0);
+            _serializer.SerializeException(response, error);
+            response.Position = 0;
+        }
     }
 }

--- a/CoreRPC/Transport/IRequest.cs
+++ b/CoreRPC/Transport/IRequest.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.IO;
 using System.Threading.Tasks;
 
 namespace CoreRPC.Transport

--- a/Tests/ErrorHandlerTests.cs
+++ b/Tests/ErrorHandlerTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using CoreRPC;
+using CoreRPC.Routing;
+using CoreRPC.Transport;
+using Xunit;
+
+namespace Tests
+{
+    public class ErrorHandlerTests
+    {
+        private const string PublicErrorMessage = "Internal server error!";
+        private const string PrivateErrorMessage = "Hello, world!";
+
+        public interface IThrowExceptions
+        {
+            Task ThrowException();
+        }
+
+        public class ThrowsIoExceptions : IThrowExceptions
+        {
+            public Task ThrowException() => throw new IOException(PrivateErrorMessage);
+        }
+
+        private class ThrowsIoExceptionsSelector : ITargetSelector
+        {
+            public object GetTarget(string target, object callContext) => new ThrowsIoExceptions();
+        }
+
+        public class SampleRequestErrorHandler : IRequestErrorHandler
+        {
+            private readonly string _response;
+
+            public SampleRequestErrorHandler(string response) => _response = response;
+
+            public List<Exception> Errors { get; } = new List<Exception>();
+
+            public string HandleError(Exception exception)
+            {
+                Errors.Add(exception);
+                return _response;
+            }
+        }
+
+        [Fact]
+        public async Task CoreRPC_Should_Forward_Exceptions_To_Request_Error_Handler_If_Available()
+        {
+            var engine = new Engine();
+            var handler = new SampleRequestErrorHandler(PublicErrorMessage);
+            var proxy = engine.CreateProxy<IThrowExceptions>(
+                new InternalThreadPoolTransport(
+                    engine.CreateRequestHandler(
+                        new ThrowsIoExceptionsSelector(),
+                        handler)));
+
+            var error = await Assert.ThrowsAnyAsync<Exception>(() => proxy.ThrowException());
+
+            Assert.NotEmpty(handler.Errors);
+            Assert.NotNull(handler.Errors[0].InnerException?.Message);
+            Assert.Equal(PrivateErrorMessage, handler.Errors[0].InnerException?.Message);
+            Assert.Equal(PublicErrorMessage, error.Message);
+        }
+    }
+}

--- a/Tests/ErrorHandlerTests.cs
+++ b/Tests/ErrorHandlerTests.cs
@@ -1,10 +1,17 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using CoreRPC;
+using CoreRPC.AspNetCore;
 using CoreRPC.Routing;
 using CoreRPC.Transport;
+using CoreRPC.Transport.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Tests
@@ -19,6 +26,7 @@ namespace Tests
             Task ThrowException();
         }
 
+        [RegisterRpc(typeof(IThrowExceptions))]
         public class ThrowsIoExceptions : IThrowExceptions
         {
             public Task ThrowException() => throw new IOException(PrivateErrorMessage);
@@ -29,11 +37,11 @@ namespace Tests
             public object GetTarget(string target, object callContext) => new ThrowsIoExceptions();
         }
 
-        public class SampleRequestErrorHandler : IRequestErrorHandler
+        public class CustomErrorHandler : IRequestErrorHandler
         {
             private readonly string _response;
 
-            public SampleRequestErrorHandler(string response) => _response = response;
+            public CustomErrorHandler(string response) => _response = response;
 
             public List<Exception> Errors { get; } = new List<Exception>();
 
@@ -45,16 +53,69 @@ namespace Tests
         }
 
         [Fact]
-        public async Task CoreRPC_Should_Forward_Exceptions_To_Request_Error_Handler_If_Available()
+        public async Task CoreRpc_Should_Forward_Exceptions_To_Request_Error_Handler()
         {
             var engine = new Engine();
-            var handler = new SampleRequestErrorHandler(PublicErrorMessage);
+            var handler = new CustomErrorHandler(PublicErrorMessage);
             var proxy = engine.CreateProxy<IThrowExceptions>(
                 new InternalThreadPoolTransport(
                     engine.CreateRequestHandler(
                         new ThrowsIoExceptionsSelector(),
                         handler)));
 
+            var error = await Assert.ThrowsAnyAsync<Exception>(() => proxy.ThrowException());
+
+            Assert.NotEmpty(handler.Errors);
+            Assert.NotNull(handler.Errors[0].InnerException?.Message);
+            Assert.Equal(PrivateErrorMessage, handler.Errors[0].InnerException?.Message);
+            Assert.Equal(PublicErrorMessage, error.Message);
+        }
+
+        [Fact]
+        public async Task CoreRpc_Should_Respond_With_Exception_Details_If_There_Is_No_Error_Handler()
+        {
+            var engine = new Engine();
+            var proxy = engine.CreateProxy<IThrowExceptions>(
+                new InternalThreadPoolTransport(
+                    engine.CreateRequestHandler(
+                        new ThrowsIoExceptionsSelector())));
+
+            var error = await Assert.ThrowsAnyAsync<Exception>(() => proxy.ThrowException());
+            Assert.Contains(PrivateErrorMessage, error.Message);
+        }
+
+        public class Startup
+        {
+            public void ConfigureServices(IServiceCollection services) =>
+                services.AddSingleton(
+                    new CustomErrorHandler(
+                        PublicErrorMessage));
+
+            public void Configure(IApplicationBuilder app) =>
+                app.UseCoreRpc("/rpc", options =>
+                {
+                    // Here we specify the custom error handler.
+                    options.ErrorHandler = app.ApplicationServices.GetService<CustomErrorHandler>();
+                    options.RpcTypeResolver = () => new[] {typeof(ThrowsIoExceptions)};
+                });
+        }
+
+        [Fact]
+        public async Task UseCoreRpc_Should_Support_Custom_Error_Handlers()
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseFreePort()
+                .UseStartup<Startup>()
+                .Build();
+
+            await host.StartAsync();
+            var addresses = host.ServerFeatures.Get<IServerAddressesFeature>();
+            var address = addresses.Addresses.First().TrimEnd('/') + "/rpc";
+            var handler = host.Services.GetRequiredService<CustomErrorHandler>();
+
+            var transport = new HttpClientTransport(address);
+            var proxy = new Engine().CreateProxy<IThrowExceptions>(transport);
             var error = await Assert.ThrowsAnyAsync<Exception>(() => proxy.ThrowException());
 
             Assert.NotEmpty(handler.Errors);


### PR DESCRIPTION
This should allow handling all possible CoreRPC exceptions (e.g. serialization etc.) without passing the exception data to the caller