### PR TITLE
feature: Generate AdditionalTypes

### DIFF
--- a/CoreRPC/Typescript/CodeGen.cs
+++ b/CoreRPC/Typescript/CodeGen.cs
@@ -116,6 +116,8 @@ namespace CoreRPC.Typescript
             code.AppendLines(fields.ToArray());
             code.End();
 
+            foreach (var attg in opts.AdditionalTypes)
+                ctx.MapType(attg);
             return (ctx + "\n" + code).Replace("\r\n", "\n");
         }
 

--- a/CoreRPC/Typescript/TypescriptGenerationOptions.cs
+++ b/CoreRPC/Typescript/TypescriptGenerationOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using CoreRPC.Binding;
 using CoreRPC.Binding.Default;
@@ -18,6 +19,7 @@ namespace CoreRPC.Typescript
         public string ClassName { get; set; } = "CoreApi";
         public Func<Type, Type> CustomTypeMapping { get; set; } = null;
         public CustomTsTypeMapping CustomTsTypeMapping { get; set; } = null;
+        public List<Type> AdditionalTypes { get; set; } = new();
     }
 
     public delegate string CustomTsTypeMapping(Type type, Func<Type, string> subTypeMapper);

--- a/Tests/TypescriptAspNetCoreTests.cs
+++ b/Tests/TypescriptAspNetCoreTests.cs
@@ -92,6 +92,11 @@ namespace Tests
         public static string StaticPropertyThisTextShouldNotExistInGeneratedFile { get; set; } = "I'm a static.";
     }
 
+    public class MyImplicitDto
+    {
+        public string MyImplicitDtoProperty { get; set; }
+    }
+
     [RegisterRpc]
     public class StaticFields
     {
@@ -122,7 +127,7 @@ namespace Tests
         {
             var code =
                 "import {default as fetch, RequestInit, Response} from \"node-fetch\";\n" +
-                AspNetCoreRpcTypescriptGenerator.GenerateCode(env);
+                AspNetCoreRpcTypescriptGenerator.GenerateCode(env, o => o.AdditionalTypes.Add(typeof(MyImplicitDto)));
             File.WriteAllText(Path.Combine(JsDir, "api.ts"), code);
         }
 
@@ -192,6 +197,8 @@ namespace Tests
             var generatedStuff = File.ReadAllText(apiTs);
             Assert.Contains(nameof(MyStaticFieldsDto.MyStaticFieldsDtoRegularProperty), generatedStuff);
             Assert.Contains(nameof(MyTsIgnoreDto.MyTsIgnoreDtoRegularProperty), generatedStuff);
+            Assert.Contains(nameof(MyImplicitDto), generatedStuff);
+            Assert.Contains(nameof(MyImplicitDto.MyImplicitDtoProperty), generatedStuff);
             Assert.DoesNotContain("ThisTextShouldNotExistInGeneratedFile", generatedStuff);
         }
     }


### PR DESCRIPTION
Now we can generate additional types that were not exported from RPC by configuring the generator:
```csharp
AspNetCoreRpcTypescriptGenerator.GenerateCode(env, o => o.AdditionalTypes.Add(typeof(MyImplicitDto)));
```