### PR TITLE
Expose Timeout for named NamedPipes

### DIFF
--- a/CoreRPC/Transport/NamedPipe/NamedPipeClientTransport.cs
+++ b/CoreRPC/Transport/NamedPipe/NamedPipeClientTransport.cs
@@ -11,11 +11,13 @@ namespace CoreRPC.Transport.NamedPipe
     {
         private readonly string _serverName;
         private readonly string _pipeName;
+        private readonly int? _timeout;
 
-        public NamedPipeClientTransport(string pipeName, string serverName = ".")
+        public NamedPipeClientTransport(string pipeName, string serverName = ".", int? timeout = null)
         {
             _serverName = serverName;
             _pipeName = pipeName;
+            _timeout = timeout;
         }
 
         
@@ -23,7 +25,14 @@ namespace CoreRPC.Transport.NamedPipe
         {
             using (var pipe = new NamedPipeClientStream(_serverName, _pipeName, PipeDirection.InOut, PipeOptions.Asynchronous))
             {
-                await pipe.ConnectAsync();
+                if (_timeout.HasValue)
+                {
+                    await pipe.ConnectAsync(_timeout.Value);
+                }
+                else
+                {
+                    await pipe.ConnectAsync();
+                }
 
                 var requestLengthBytes = BitConverter.GetBytes(message.Length);
                 await pipe.WriteAsync(requestLengthBytes, 0, 4);


### PR DESCRIPTION
Allow to set the timeout for the NamedPipe connection in NamedPipeClientTransport.
This allows to handle situations where the server might be unavailable without getting infinitely stuck on a method call. 
The parameter is optional, and previous behavior is maintained as default. 